### PR TITLE
Use relative_url for assets

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,8 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
-	<link rel="stylesheet" type="text/css" href="/css/foundation.min.css">
-	<link rel="stylesheet" type="text/css" href="/css/main.css">
+        <link rel="stylesheet" type="text/css" href="{{ '/css/foundation.min.css' | relative_url }}">
+        <link rel="stylesheet" type="text/css" href="{{ '/css/main.css' | relative_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 	<script type="text/javascript"
@@ -36,9 +36,9 @@
 </div>
 </div>
 
-<script src="/js/jquery.js"></script>
-<script src="/js/foundation.min.js"></script>
-<script src="/js/app.js"></script>  
+<script src="{{ '/js/jquery.js' | relative_url }}"></script>
+<script src="{{ '/js/foundation.min.js' | relative_url }}"></script>
+<script src="{{ '/js/app.js' | relative_url }}"></script>
 
 </body>
 </html>

--- a/_layouts/photos.html
+++ b/_layouts/photos.html
@@ -7,8 +7,8 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
-	<link rel="stylesheet" type="text/css" href="/css/foundation.min.css">
-	<link rel="stylesheet" type="text/css" href="/css/main.css">
+        <link rel="stylesheet" type="text/css" href="{{ '/css/foundation.min.css' | relative_url }}">
+        <link rel="stylesheet" type="text/css" href="{{ '/css/main.css' | relative_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 	<script type="text/javascript"
@@ -30,9 +30,9 @@
 {{ content }}
 </div>
 
-<script src="/js/jquery.js"></script>
-<script src="/js/foundation.min.js"></script>
-<script src="/js/app.js"></script>
+<script src="{{ '/js/jquery.js' | relative_url }}"></script>
+<script src="{{ '/js/foundation.min.js' | relative_url }}"></script>
+<script src="{{ '/js/app.js' | relative_url }}"></script>
 
 </body>
 </html>

--- a/_posts/2015-01-12-Vietnam.markdown
+++ b/_posts/2015-01-12-Vietnam.markdown
@@ -6,150 +6,150 @@ category: Travel
 
 ## First stop: Prague, Czech Republic
 
-<img src="/images/vietnam/1_ndqLCt08Y31ejli4u4sCoA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_ndqLCt08Y31ejli4u4sCoA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_U5XZUlrH9DnUmnRtVY3cxQ.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_U5XZUlrH9DnUmnRtVY3cxQ.jpg' | relative_url }}" width="800" />
 
 ## Second stop: Incheon, Korea
 
-<img src="/images/vietnam/1_x00VtRXgWggSe04mVf4hQw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_x00VtRXgWggSe04mVf4hQw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_wisoiaNhXvF2DWA9g16Ziw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_wisoiaNhXvF2DWA9g16Ziw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_bUraXYz_izxFrePHnZ1xbQ.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_bUraXYz_izxFrePHnZ1xbQ.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_noK_211nuaJmoAspKqS00A.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_noK_211nuaJmoAspKqS00A.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_f1KBuVI0LeNdklCB49CC4A.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_f1KBuVI0LeNdklCB49CC4A.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_yER9moZPLibOLGtoaSmjZw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_yER9moZPLibOLGtoaSmjZw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_uNMsox9XpXcHSs0SS0G6ZA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_uNMsox9XpXcHSs0SS0G6ZA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_s9Aw-7gsNFRNfYeW7asTeg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_s9Aw-7gsNFRNfYeW7asTeg.jpg' | relative_url }}" width="800" />
 
 ## Finally there: Hanoi, Vietnam
 
-<img src="/images/vietnam/1_WKjO1ziXib89mtJbUnV_sA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_WKjO1ziXib89mtJbUnV_sA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_uUNEqezjNkhVduQcu6Vplw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_uUNEqezjNkhVduQcu6Vplw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_pLV_YP886Q1d4q7TxeOeDA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_pLV_YP886Q1d4q7TxeOeDA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_2E-QdThzeCPUAHjYsEn94A.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_2E-QdThzeCPUAHjYsEn94A.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_I4MhiS9JEKowry1tVOBoGA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_I4MhiS9JEKowry1tVOBoGA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_KHKGt96gYt3okQSbWpD6Dw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_KHKGt96gYt3okQSbWpD6Dw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_opUSbj2rjtFvE-6dB9f-IQ.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_opUSbj2rjtFvE-6dB9f-IQ.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_UN4C6QCvZXPT-3qJZYzs0w.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_UN4C6QCvZXPT-3qJZYzs0w.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_rY5WkSKAcmjMS11ptSqF8Q.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_rY5WkSKAcmjMS11ptSqF8Q.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_ZWxMtzbHKNmCz5jqiU3cNw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_ZWxMtzbHKNmCz5jqiU3cNw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_DAmAFDJydPIr5Zvu1bqx9A.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_DAmAFDJydPIr5Zvu1bqx9A.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_kd3U561H8aUjSxmatCWrSA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_kd3U561H8aUjSxmatCWrSA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_dHM56W7Hg5dmK_JVkvJbIA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_dHM56W7Hg5dmK_JVkvJbIA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_SadbxPqVRKRbMUn6_Oe_kg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_SadbxPqVRKRbMUn6_Oe_kg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_MhhUSMJ7Iuo7ggek9WRnlQ.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_MhhUSMJ7Iuo7ggek9WRnlQ.jpg' | relative_url }}" width="800" />
 
 ## Hué, Vietnam
 
-<img src="/images/vietnam/1_oZOkGiL9Ppj4rZgFpENSzw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_oZOkGiL9Ppj4rZgFpENSzw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_0yRCL97bguJXVW_xQh2X9g.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_0yRCL97bguJXVW_xQh2X9g.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_ATyZHp7WMC9pEMip18W5iA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_ATyZHp7WMC9pEMip18W5iA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_dVwaGHqsb0I96B6EPJhbvw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_dVwaGHqsb0I96B6EPJhbvw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_QrFzbIhgLi_kB0mROoR03g.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_QrFzbIhgLi_kB0mROoR03g.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_kTeHibVIbr_NtcD7TQZg3w.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_kTeHibVIbr_NtcD7TQZg3w.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_r8njdjsBVCUd7NeraLueeg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_r8njdjsBVCUd7NeraLueeg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_4Vhkto1nq2FvJjqcNfXEtg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_4Vhkto1nq2FvJjqcNfXEtg.jpg' | relative_url }}" width="800" />
 
 ## Hoi An, Vietnam
 
-<img src="/images/vietnam/1_zOyPCv981awCyH7irKIgKA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_zOyPCv981awCyH7irKIgKA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_3Jot_x702INKihUs50IuiA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_3Jot_x702INKihUs50IuiA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_IZcLn1aj24r0cr0uXrofbw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_IZcLn1aj24r0cr0uXrofbw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_ZDtp6tk6sd8_WK8hXpUsLA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_ZDtp6tk6sd8_WK8hXpUsLA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_2el8y3pl4RmLozwgUTevZQ.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_2el8y3pl4RmLozwgUTevZQ.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_PLUecLpbGUmNt5W5RSOnbg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_PLUecLpbGUmNt5W5RSOnbg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_jkxyIMvWWjTl2Q2KhT2Mmg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_jkxyIMvWWjTl2Q2KhT2Mmg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_3vgBgRS3QnzYTmrmoKMOdg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_3vgBgRS3QnzYTmrmoKMOdg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_AnKYEs6ywBfYV591AKAX-Q.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_AnKYEs6ywBfYV591AKAX-Q.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_ti8oOLF_1xJSr3BQE2cjRA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_ti8oOLF_1xJSr3BQE2cjRA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_zTfnZkmwPxvQVMqC4m62Fg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_zTfnZkmwPxvQVMqC4m62Fg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_A0r82KRXAEgHXA4OW-b1ZQ.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_A0r82KRXAEgHXA4OW-b1ZQ.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_eBKibC-qdourmG0g9gTt3Q.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_eBKibC-qdourmG0g9gTt3Q.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_QnHX5boEw5rKIOw_v2qQ3A.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_QnHX5boEw5rKIOw_v2qQ3A.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_tmVz-i40H6r-z5loOcbu0w.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_tmVz-i40H6r-z5loOcbu0w.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_QlE3ozwii0JCCDGGw70Y4Q.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_QlE3ozwii0JCCDGGw70Y4Q.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_C1_cTA0rnQManAWgIU73jg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_C1_cTA0rnQManAWgIU73jg.jpg' | relative_url }}" width="800" />
 
 ## Saigon, Vietnam
 
-<img src="/images/vietnam/1_vC5ZUPMSbSPC5BGVBMhWKw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_vC5ZUPMSbSPC5BGVBMhWKw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_ZXDr62hJ8DRKpm2mqlOkdA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_ZXDr62hJ8DRKpm2mqlOkdA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_wqybazlNkSmZgKw9zUFKfg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_wqybazlNkSmZgKw9zUFKfg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_CMYJBl8S9Mz2h89y1LXTKg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_CMYJBl8S9Mz2h89y1LXTKg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_iBOgdI4TtpY3LnpoXEqc9Q.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_iBOgdI4TtpY3LnpoXEqc9Q.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_LHc2m05iCNWxdv-YsTZ7MA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_LHc2m05iCNWxdv-YsTZ7MA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_JY0sQkrwR9JfbupN42tirg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_JY0sQkrwR9JfbupN42tirg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_ecVu8cslCu_OcPujXLpJkQ.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_ecVu8cslCu_OcPujXLpJkQ.jpg' | relative_url }}" width="800" />
 
 ## Da Lat, Vietnam
 
-<img src="/images/vietnam/1_MkdAzUq6jXy_S6gussh_HQ.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_MkdAzUq6jXy_S6gussh_HQ.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_DYIPM_Euykxzcw8DCB5I9g.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_DYIPM_Euykxzcw8DCB5I9g.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_TA7VMdvwC5QUEY_XKUNCow.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_TA7VMdvwC5QUEY_XKUNCow.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_7KXv0MoYS9-RZkYRHdBIgg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_7KXv0MoYS9-RZkYRHdBIgg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_fNhiDsl6Jb7LshhWCpTRbA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_fNhiDsl6Jb7LshhWCpTRbA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_rRKz5xPgNiD9pQecOuypcw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_rRKz5xPgNiD9pQecOuypcw.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_JATh-mxLoQx12b50ICUuQg.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_JATh-mxLoQx12b50ICUuQg.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_QZz3lnRnLU00MRkWNIiztA.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_QZz3lnRnLU00MRkWNIiztA.jpg' | relative_url }}" width="800" />
 
-<img src="/images/vietnam/1_iTH4UBCuT7TSDLPtX8Q-Hw.jpg" width="800" />
+<img src="{{ '/images/vietnam/1_iTH4UBCuT7TSDLPtX8Q-Hw.jpg' | relative_url }}" width="800" />
 
 <p>&nbsp;</p>

--- a/_posts/2018-01-15-photos-of-2017.md
+++ b/_posts/2018-01-15-photos-of-2017.md
@@ -7,334 +7,334 @@ category: Photos
 
 ## Amsterdam
 
-<img src="/images/2017/1.jpg" width="800" />
+<img src="{{ '/images/2017/1.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/3.jpg" width="800" />
+<img src="{{ '/images/2017/3.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/5.jpg" width="800" />
+<img src="{{ '/images/2017/5.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/8.jpg" width="800" />
+<img src="{{ '/images/2017/8.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/12.jpg" width="800" />
+<img src="{{ '/images/2017/12.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/13.jpg" width="800" />
+<img src="{{ '/images/2017/13.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/14.jpg" width="800" />
+<img src="{{ '/images/2017/14.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/24.jpg" width="800" />
+<img src="{{ '/images/2017/24.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/25.jpg" width="800" />
+<img src="{{ '/images/2017/25.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/29.jpg" width="800" />
+<img src="{{ '/images/2017/29.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/30.jpg" width="800" />
+<img src="{{ '/images/2017/30.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/31.jpg" width="800" />
+<img src="{{ '/images/2017/31.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/32.jpg" width="800" />
+<img src="{{ '/images/2017/32.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/33.jpg" width="800" />
+<img src="{{ '/images/2017/33.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/34.jpg" width="800" />
+<img src="{{ '/images/2017/34.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/35.jpg" width="800" />
+<img src="{{ '/images/2017/35.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/36.jpg" width="800" />
+<img src="{{ '/images/2017/36.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/37.jpg" width="800" />
+<img src="{{ '/images/2017/37.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/38.jpg" width="800" />
+<img src="{{ '/images/2017/38.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/39.jpg" width="800" />
+<img src="{{ '/images/2017/39.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/40.jpg" width="800" />
+<img src="{{ '/images/2017/40.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/41.jpg" width="800" />
+<img src="{{ '/images/2017/41.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/42.jpg" width="800" />
+<img src="{{ '/images/2017/42.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/43.jpg" width="800" />
+<img src="{{ '/images/2017/43.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/44.jpg" width="800" />
+<img src="{{ '/images/2017/44.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/45.jpg" width="800" />
+<img src="{{ '/images/2017/45.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/46.jpg" width="800" />
+<img src="{{ '/images/2017/46.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/47.jpg" width="800" />
+<img src="{{ '/images/2017/47.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/48.jpg" width="800" />
+<img src="{{ '/images/2017/48.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/49.jpg" width="800" />
+<img src="{{ '/images/2017/49.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/50.jpg" width="800" />
+<img src="{{ '/images/2017/50.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/51.jpg" width="800" />
+<img src="{{ '/images/2017/51.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/52.jpg" width="800" />
+<img src="{{ '/images/2017/52.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/53.jpg" width="800" />
+<img src="{{ '/images/2017/53.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/54.jpg" width="800" />
+<img src="{{ '/images/2017/54.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/55.jpg" width="800" />
+<img src="{{ '/images/2017/55.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/56.jpg" width="800" />
+<img src="{{ '/images/2017/56.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/57.jpg" width="800" />
+<img src="{{ '/images/2017/57.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/58.jpg" width="800" />
+<img src="{{ '/images/2017/58.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/59.jpg" width="800" />
+<img src="{{ '/images/2017/59.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/60.jpg" width="800" />
+<img src="{{ '/images/2017/60.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/61.jpg" width="800" />
+<img src="{{ '/images/2017/61.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/62.jpg" width="800" />
+<img src="{{ '/images/2017/62.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/63.jpg" width="800" />
+<img src="{{ '/images/2017/63.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/69.jpg" width="800" />
+<img src="{{ '/images/2017/69.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/70.jpg" width="800" />
+<img src="{{ '/images/2017/70.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/71.jpg" width="800" />
+<img src="{{ '/images/2017/71.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/72.jpg" width="800" />
+<img src="{{ '/images/2017/72.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/74.jpg" width="800" />
+<img src="{{ '/images/2017/74.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/75.jpg" width="800" />
+<img src="{{ '/images/2017/75.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/76.jpg" width="800" />
+<img src="{{ '/images/2017/76.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/77.jpg" width="800" />
+<img src="{{ '/images/2017/77.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/87.jpg" width="800" />
+<img src="{{ '/images/2017/87.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/88.jpg" width="800" />
+<img src="{{ '/images/2017/88.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/89.jpg" width="800" />
+<img src="{{ '/images/2017/89.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/90.jpg" width="800" />
+<img src="{{ '/images/2017/90.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/115.jpg" width="800" />
+<img src="{{ '/images/2017/115.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/116.jpg" width="800" />
+<img src="{{ '/images/2017/116.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/117.jpg" width="800" />
+<img src="{{ '/images/2017/117.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/118.jpg" width="800" />
+<img src="{{ '/images/2017/118.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/119.jpg" width="800" />
+<img src="{{ '/images/2017/119.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/120.jpg" width="800" />
+<img src="{{ '/images/2017/120.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/121.jpg" width="800" />
+<img src="{{ '/images/2017/121.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/122.jpg" width="800" />
+<img src="{{ '/images/2017/122.jpg' | relative_url }}" width="800" />
 
 
 
 ## Belgium
 
-<img src="/images/2017/6.jpg" width="800" />
+<img src="{{ '/images/2017/6.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/7.jpg" width="800" />
+<img src="{{ '/images/2017/7.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/9.jpg" width="800" />
+<img src="{{ '/images/2017/9.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/10.jpg" width="800" />
+<img src="{{ '/images/2017/10.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/11.jpg" width="800" />
+<img src="{{ '/images/2017/11.jpg' | relative_url }}" width="800" />
 
 
 ## Germany
 
-<img src="/images/2017/15.jpg" width="800" />
+<img src="{{ '/images/2017/15.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/16.jpg" width="800" />
+<img src="{{ '/images/2017/16.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/17.jpg" width="800" />
+<img src="{{ '/images/2017/17.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/18.jpg" width="800" />
+<img src="{{ '/images/2017/18.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/26.jpg" width="800" />
+<img src="{{ '/images/2017/26.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/27.jpg" width="800" />
+<img src="{{ '/images/2017/27.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/28.jpg" width="800" />
+<img src="{{ '/images/2017/28.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/68.jpg" width="800" />
+<img src="{{ '/images/2017/68.jpg' | relative_url }}" width="800" />
 
 
 ## San Francisco bay area
 
-<img src="/images/2017/2.jpg" width="800" />
+<img src="{{ '/images/2017/2.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/19.jpg" width="800" />
+<img src="{{ '/images/2017/19.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/20.jpg" width="800" />
+<img src="{{ '/images/2017/20.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/21.jpg" width="800" />
+<img src="{{ '/images/2017/21.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/22.jpg" width="800" />
+<img src="{{ '/images/2017/22.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/23.jpg" width="800" />
+<img src="{{ '/images/2017/23.jpg' | relative_url }}" width="800" />
 
 
 ## Scotland
 
-<img src="/images/2017/4.jpg" width="800" />
+<img src="{{ '/images/2017/4.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/92.jpg" width="800" />
+<img src="{{ '/images/2017/92.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/93.jpg" width="800" />
+<img src="{{ '/images/2017/93.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/94.jpg" width="800" />
+<img src="{{ '/images/2017/94.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/95.jpg" width="800" />
+<img src="{{ '/images/2017/95.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/96.jpg" width="800" />
+<img src="{{ '/images/2017/96.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/97.jpg" width="800" />
+<img src="{{ '/images/2017/97.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/98.jpg" width="800" />
+<img src="{{ '/images/2017/98.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/99.jpg" width="800" />
+<img src="{{ '/images/2017/99.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/100.jpg" width="800" />
+<img src="{{ '/images/2017/100.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/101.jpg" width="800" />
+<img src="{{ '/images/2017/101.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/102.jpg" width="800" />
+<img src="{{ '/images/2017/102.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/103.jpg" width="800" />
+<img src="{{ '/images/2017/103.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/104.jpg" width="800" />
+<img src="{{ '/images/2017/104.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/105.jpg" width="800" />
+<img src="{{ '/images/2017/105.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/106.jpg" width="800" />
+<img src="{{ '/images/2017/106.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/107.jpg" width="800" />
+<img src="{{ '/images/2017/107.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/109.jpg" width="800" />
+<img src="{{ '/images/2017/109.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/110.jpg" width="800" />
+<img src="{{ '/images/2017/110.jpg' | relative_url }}" width="800" />
 
 
 
 ## Austria
 
 
-<img src="/images/2017/64.jpg" width="800" />
+<img src="{{ '/images/2017/64.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/65.jpg" width="800" />
+<img src="{{ '/images/2017/65.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/66.jpg" width="800" />
+<img src="{{ '/images/2017/66.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/67.jpg" width="800" />
+<img src="{{ '/images/2017/67.jpg' | relative_url }}" width="800" />
 
 
 
 ## Barcelona & Girona
 
-<img src="/images/2017/78.jpg" width="800" />
+<img src="{{ '/images/2017/78.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/79.jpg" width="800" />
+<img src="{{ '/images/2017/79.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/81.jpg" width="800" />
+<img src="{{ '/images/2017/81.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/82.jpg" width="800" />
+<img src="{{ '/images/2017/82.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/83.jpg" width="800" />
+<img src="{{ '/images/2017/83.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/84.jpg" width="800" />
+<img src="{{ '/images/2017/84.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/85.jpg" width="800" />
+<img src="{{ '/images/2017/85.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/86.jpg" width="800" />
+<img src="{{ '/images/2017/86.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/111.jpg" width="800" />
+<img src="{{ '/images/2017/111.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/112.jpg" width="800" />
+<img src="{{ '/images/2017/112.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/113.jpg" width="800" />
+<img src="{{ '/images/2017/113.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/114.jpg" width="800" />
+<img src="{{ '/images/2017/114.jpg' | relative_url }}" width="800" />
 
 
 
 ## Venice
 
-<img src="/images/2017/123.jpg" width="800" />
+<img src="{{ '/images/2017/123.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/124.jpg" width="800" />
+<img src="{{ '/images/2017/124.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/125.jpg" width="800" />
+<img src="{{ '/images/2017/125.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/126.jpg" width="800" />
+<img src="{{ '/images/2017/126.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/127.jpg" width="800" />
+<img src="{{ '/images/2017/127.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/128.jpg" width="800" />
+<img src="{{ '/images/2017/128.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/129.jpg" width="800" />
+<img src="{{ '/images/2017/129.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/130.jpg" width="800" />
+<img src="{{ '/images/2017/130.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/131.jpg" width="800" />
+<img src="{{ '/images/2017/131.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/132.jpg" width="800" />
+<img src="{{ '/images/2017/132.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/133.jpg" width="800" />
+<img src="{{ '/images/2017/133.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/134.jpg" width="800" />
+<img src="{{ '/images/2017/134.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/135.jpg" width="800" />
+<img src="{{ '/images/2017/135.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/136.jpg" width="800" />
+<img src="{{ '/images/2017/136.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/137.jpg" width="800" />
+<img src="{{ '/images/2017/137.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/138.jpg" width="800" />
+<img src="{{ '/images/2017/138.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/139.jpg" width="800" />
+<img src="{{ '/images/2017/139.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/140.jpg" width="800" />
+<img src="{{ '/images/2017/140.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/141.jpg" width="800" />
+<img src="{{ '/images/2017/141.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/142.jpg" width="800" />
+<img src="{{ '/images/2017/142.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/143.jpg" width="800" />
+<img src="{{ '/images/2017/143.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/144.jpg" width="800" />
+<img src="{{ '/images/2017/144.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/145.jpg" width="800" />
+<img src="{{ '/images/2017/145.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/146.jpg" width="800" />
+<img src="{{ '/images/2017/146.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/147.jpg" width="800" />
+<img src="{{ '/images/2017/147.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/148.jpg" width="800" />
+<img src="{{ '/images/2017/148.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/149.jpg" width="800" />
+<img src="{{ '/images/2017/149.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/150.jpg" width="800" />
+<img src="{{ '/images/2017/150.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/151.jpg" width="800" />
+<img src="{{ '/images/2017/151.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/152.jpg" width="800" />
+<img src="{{ '/images/2017/152.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/153.jpg" width="800" />
+<img src="{{ '/images/2017/153.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/154.jpg" width="800" />
+<img src="{{ '/images/2017/154.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/155.jpg" width="800" />
+<img src="{{ '/images/2017/155.jpg' | relative_url }}" width="800" />
 
-<img src="/images/2017/156.jpg" width="800" />
+<img src="{{ '/images/2017/156.jpg' | relative_url }}" width="800" />
 
 <p>&nbsp;</p>

--- a/_posts/2018-12-01-Bali.markdown
+++ b/_posts/2018-12-01-Bali.markdown
@@ -6,30 +6,30 @@ category: Travel
 
 ## Ubud, Indonesia
 
-<img src="/images/bali/ubud_1.jpg" width="800" />
+<img src="{{ '/images/bali/ubud_1.jpg' | relative_url }}" width="800" />
 
-<img src="/images/bali/ubud_4.jpg" width="800" />
+<img src="{{ '/images/bali/ubud_4.jpg' | relative_url }}" width="800" />
 
-<img src="/images/bali/ubud_5.jpg" width="800" />
+<img src="{{ '/images/bali/ubud_5.jpg' | relative_url }}" width="800" />
 
-<img src="/images/bali/ubud_7.jpg" width="800" />
+<img src="{{ '/images/bali/ubud_7.jpg' | relative_url }}" width="800" />
 
-<img src="/images/bali/ubud_9.jpg" width="800" />
+<img src="{{ '/images/bali/ubud_9.jpg' | relative_url }}" width="800" />
 
 ## Batur, Indonesia
 
-<img src="/images/bali/batur_1.jpg" width="800" />
+<img src="{{ '/images/bali/batur_1.jpg' | relative_url }}" width="800" />
 
-<img src="/images/bali/batur_2.jpg" width="800" />
+<img src="{{ '/images/bali/batur_2.jpg' | relative_url }}" width="800" />
 
-<img src="/images/bali/batur_3.jpg" width="800" />
+<img src="{{ '/images/bali/batur_3.jpg' | relative_url }}" width="800" />
 
-<img src="/images/bali/batur_4.jpg" width="800" />
+<img src="{{ '/images/bali/batur_4.jpg' | relative_url }}" width="800" />
 
 ## Nusa Penida, Indonesia
 
-<img src="/images/bali/nusa_1.jpg" width="800" />
+<img src="{{ '/images/bali/nusa_1.jpg' | relative_url }}" width="800" />
 
-<img src="/images/bali/nusa_4.jpg" width="800" />
+<img src="{{ '/images/bali/nusa_4.jpg' | relative_url }}" width="800" />
 
-<img src="/images/bali/kuta_2.jpg" width="800" /> 
+<img src="{{ '/images/bali/kuta_2.jpg' | relative_url }}" width="800" /> 

--- a/css/main.css
+++ b/css/main.css
@@ -329,6 +329,9 @@ html,body {
     #layout {
         padding: 0;
     }
+    h1 {
+        font-size: 2.25rem;
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- use `relative_url` filter for CSS and JS so builds hosted in subdirectories work
- enlarge the mobile `h1` font size
- use `relative_url` for image paths so photo posts render correctly in previews

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_6872046e620c832693dacb182ed5d900