### PR TITLE
Fix post wrap indentation

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -438,13 +438,21 @@ ul.publications li {
 }
 
 .posts li {
-  display: list-item;
-  align-items: initial;
-  gap: initial;
+  display: flex;
+  align-items: flex-start;
 }
 .date-align {
   display: inline-block;
-  margin-right: 0em;
+  width: 8ch;
+  margin-right: 0.25em;
   text-align: right;
   font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.seperator {
+  flex-shrink: 0;
+  margin-right: 0.25em;
+}
+.post-desc {
+  flex: 1 1 auto;
 }

--- a/index.md
+++ b/index.md
@@ -26,9 +26,10 @@ in applications and evaluation of large language and vision models, machine tran
 
 ## News
 
-- <span class="date-align">Nov 2024</span> <span class="seperator">~</span> Objective, Inc. was acquired by Upwork.
-- <span class="date-align">Sep 2021</span> <span class="seperator">~</span> I started [Objective, Inc.](https://techcrunch.com/2023/10/18/objective-emerges-from-stealth-to-deliver-multimodal-search-to-developers-as-an-api-platform/) with Pablo and Lance.
-- <span class="date-align">Jul 2020</span> <span class="seperator">~</span> MKQA paper published in TACL, first machine learning dataset by Apple.
+- <span class="date-align">Nov 2024</span> <span class="seperator">~</span> <span class="post-desc">Objective, Inc. was acquired by Upwork.</span>
+- <span class="date-align">Sep 2021</span> <span class="seperator">~</span> <span class="post-desc">I started [Objective, Inc.](https://techcrunch.com/2023/10/18/objective-emerges-from-stealth-to-deliver-multimodal-search-to-developers-as-an-api-platform/) with Pablo and Lance.</span>
+- <span class="date-align">Jul 2020</span> <span class="seperator">~</span> <span class="post-desc">MKQA paper published in TACL, first machine learning dataset by Apple.</span>
+{: .posts}
 
 {% for post in site.posts %}
 
@@ -40,9 +41,9 @@ in applications and evaluation of large language and vision models, machine tran
 {% endif %}
 
     {% if post.external_url %}
-    	<li><span class="date-align">{{ post.date | date_to_string }}</span> <span class="seperator">~</span> {{ post.category }}: <a href="{{ post.external_url }}">{{ post.title }}</a></li>
+        <li><span class="date-align">{{ post.date | date_to_string }}</span> <span class="seperator">~</span> <span class="post-desc">{{ post.category }}: <a href="{{ post.external_url }}">{{ post.title }}</a></span></li>
     {% else %}
-    	<li><span class="date-align">{{ post.date | date_to_string }}</span> <span class="seperator">~</span> {{ post.category }}: <a href="{{ post.url }}">{{ post.title }}</a></li>
+        <li><span class="date-align">{{ post.date | date_to_string }}</span> <span class="seperator">~</span> <span class="post-desc">{{ post.category }}: <a href="{{ post.url }}">{{ post.title }}</a></span></li>
     {% endif %}
 
  


### PR DESCRIPTION
## Summary
- make post entries flex containers and size date span
- wrap post text after `~` in its own span
- apply alignment fix to News section list

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_6872ff66a2d08326a67b7f3a4f8ca113