### PR TITLE
Fix preview workflow cleanup

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -31,12 +31,14 @@ jobs:
       - uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: _site           # folder Jekyll just built
+          single-commit: true
 
   # Garbage-collect the preview when the PR is closed
   cleanup:
     runs-on: ubuntu-latest
     if: github.event.action == 'closed'
     steps:
+      - uses: actions/checkout@v4
       - uses: rossjrw/pr-preview-action@v1
         with:
           deploy-preview: delete


### PR DESCRIPTION
## Summary
- add `actions/checkout@v4` to the cleanup job so the preview removal has a repo
- keep the preview branch small with `single-commit: true`

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6872fca3aee88326bd6e6b455ab7c355