### PR TITLE
Fix titles for Bali and Vietnam

### DIFF
--- a/_posts/2015-01-12-Vietnam.markdown
+++ b/_posts/2015-01-12-Vietnam.markdown
@@ -1,6 +1,6 @@
 ---
 layout: photos
-title: Vietnam 2014
+title: Vietnam
 category: Travel
 ---
 

--- a/_posts/2018-12-01-Bali.markdown
+++ b/_posts/2018-12-01-Bali.markdown
@@ -1,6 +1,6 @@
 ---
 layout: photos
-title: Bali 2018
+title: Bali
 category: Travel
 ---
 


### PR DESCRIPTION
## Summary
- remove year numbers from Bali and Vietnam post titles

## Testing
- `bundle install` *(fails: `jekyll` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68734cf23c588326bffeebc872848590