### PR TITLE
Update CSS to use Google Fonts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,8 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Merriweather:wght@400;700&display=swap">
         <link rel="stylesheet" type="text/css" href="{{ '/css/foundation.min.css' | relative_url }}">
         <link rel="stylesheet" type="text/css" href="{{ '/css/main.css' | relative_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/_layouts/photos.html
+++ b/_layouts/photos.html
@@ -6,7 +6,8 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Merriweather:wght@400;700&display=swap">
         <link rel="stylesheet" type="text/css" href="{{ '/css/foundation.min.css' | relative_url }}">
         <link rel="stylesheet" type="text/css" href="{{ '/css/main.css' | relative_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/css/main.css
+++ b/css/main.css
@@ -1,4 +1,6 @@
-	html {
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Merriweather:wght@400;700&display=swap');
+
+        html {
 			height: 100%;
 
 		}
@@ -71,7 +73,7 @@ html,body {
 			text-transform: uppercase;
 
 			padding: 14px;
-			font-family: "Minion Web", "Georgia", serif;
+                        font-family: 'Merriweather', serif;
 
 			font-size: 150%;
 			vertical-align: bottom;
@@ -137,7 +139,7 @@ html,body {
 
 			color: #30261d;
 			color: #3d3935;
-			font-family: "Minion Web", "Georgia", serif;
+                        font-family: 'Merriweather', serif;
 
 			width: 100%;
 			
@@ -165,7 +167,7 @@ html,body {
 		#dict-def {
 			margin-top: 10px;
 			display: inline-block;
-			font-family: Georgia;
+                        font-family: 'Merriweather', serif;
 		}
 		strong {
 		}
@@ -356,7 +358,7 @@ ul.publications li {
 
     text-decoration: none;
     text-transform: uppercase;
-    font-family: "Minion Web", "Georgia", serif;
+    font-family: 'Merriweather', serif;
     color: #fff;
 }
 .headerphoto > a {
@@ -371,7 +373,7 @@ ul.publications li {
     border-left: 1px solid #eee;
     text-transform: none;
 
-    font-family: Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
+    font-family: 'Inter', sans-serif;
 
 }
 .outer {


### PR DESCRIPTION
## Summary
- import Merriweather and Inter from Google Fonts
- apply fonts in CSS
- include font links in HTML layouts

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6873d30b03608326aff35a46b11ea86e