### PR TITLE
Add fallback fonts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
         <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Merriweather:wght@400;700&display=swap">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap">
         <link rel="stylesheet" type="text/css" href="{{ '/css/foundation.min.css' | relative_url }}">
         <link rel="stylesheet" type="text/css" href="{{ '/css/main.css' | relative_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,8 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Merriweather:wght@400;700&display=swap">
         <link rel="stylesheet" type="text/css" href="{{ '/css/foundation.min.css' | relative_url }}">
         <link rel="stylesheet" type="text/css" href="{{ '/css/main.css' | relative_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/_layouts/photos.html
+++ b/_layouts/photos.html
@@ -7,7 +7,7 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
         <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Merriweather:wght@400;700&display=swap">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap">
         <link rel="stylesheet" type="text/css" href="{{ '/css/foundation.min.css' | relative_url }}">
         <link rel="stylesheet" type="text/css" href="{{ '/css/main.css' | relative_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/_layouts/photos.html
+++ b/_layouts/photos.html
@@ -6,7 +6,8 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Merriweather:wght@400;700&display=swap">
         <link rel="stylesheet" type="text/css" href="{{ '/css/foundation.min.css' | relative_url }}">
         <link rel="stylesheet" type="text/css" href="{{ '/css/main.css' | relative_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/css/main.css
+++ b/css/main.css
@@ -128,9 +128,16 @@ html,body {
 		}
 
 			
-		.content ul {
-			padding-left: 20px;
-		}
+				.content ul{
+				    list-style-type: square;      
+				    list-style-position: outside; 
+				    margin: 0 0 1.25rem;          
+				    padding-left: 1.85rem;         
+				}
+
+				li{
+				    padding: 0 0 5px;             /* restore spacing under each item */
+				}
 
                 h1 {
                         clear: none;
@@ -154,7 +161,6 @@ html,body {
                         margin-block: 0.8em 1.2em;
                         hyphens: auto;
 		}		
-		li { list-style-type: square; padding-bottom: 5px; }		
 		pre {
 			overflow-x: auto;
 		}

--- a/css/main.css
+++ b/css/main.css
@@ -109,13 +109,13 @@ html,body {
 		h1, h2 {
 
 		}
-		h2 {
-			text-transform: uppercase;
-			margin: 2em 0 0 0;
-			color: #333;
-			font-size: 120%;
-			font-weight: normal;
-			border-bottom: 1px solid #ddd;	
+               h2 {
+                        text-transform: uppercase;
+                        margin: 2.5rem 0 0 0;
+                        color: #333;
+                        font-size: 120%;
+                        font-weight: normal;
+                        border-bottom: 1px solid #ddd;
 			
 			line-height: 130%;
 			vertical-align: baseline;
@@ -128,9 +128,9 @@ html,body {
 			padding-left: 20px;
 		}
 
-		h1 {
-			clear: none;
-			display: inline-block;
+                h1 {
+                        clear: none;
+                        display: inline-block;
 			
 			/*color: white;
 			
@@ -138,8 +138,9 @@ html,body {
 			margin-top: 40px;
 
 			color: #30261d;
-			color: #3d3935;
+                        color: #3d3935;
                         font-family: 'Merriweather', 'Minion Web', 'Georgia', serif;
+                        font-weight: 600;
 
 			width: 100%;
 			
@@ -336,6 +337,7 @@ html,body {
     }
     h1 {
         font-size: 2.25rem;
+        font-weight: 600;
     }
 }
 
@@ -464,5 +466,9 @@ ul.publications li {
 
 @media (min-width: 48rem) {
   body { line-height: 1.45; }
+}
+
+@media (max-width: 23rem) {
+  body { line-height: 1.55; }
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -144,7 +144,6 @@ html,body {
 			color: #30261d;
                         color: #3d3935;
                         font-family: 'Merriweather', 'Minion Web', 'Georgia', serif;
-                        font-weight: 600;
 
 			width: 100%;
 			
@@ -409,10 +408,11 @@ ul.publications li {
     text-align: center;
 }
 .photos h2 {
-	font-weight: bold;
 	border-bottom: none;
 	font-size: 170%;
 	color: #555;
+	
+    font-weight: 500; /* or 300 for lighter, or 500 for medium */
 }
 
 .photo .image {

--- a/css/main.css
+++ b/css/main.css
@@ -131,8 +131,8 @@ html,body {
 				.content ul{
 				    list-style-type: square;      
 				    list-style-position: outside; 
-				    margin: 0 0 1.25rem;          
-				    padding-left: 1.85rem;         
+				    margin: 0 0 1.75rem;          
+				    padding-left: 1.8rem;         
 				}
 
 				li{

--- a/css/main.css
+++ b/css/main.css
@@ -1,13 +1,15 @@
-	html {
-			height: 100%;
+        html {
+                        height: 100%;
 
 		}
-		body {
-			
-			margin: 0 0 0 0;
-			padding: 0;
-			
-		}
+                body {
+                        font-family: 'Inter', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
+                        margin: 0 0 0 0;
+                        padding: 0;
+                        font-size: 18px;
+                        line-height: 1.5;
+
+                }
 	
 html,body {
     height:100%;
@@ -71,7 +73,7 @@ html,body {
 			text-transform: uppercase;
 
 			padding: 14px;
-			font-family: "Minion Web", "Georgia", serif;
+                        font-family: 'Merriweather', 'Minion Web', 'Georgia', serif;
 
 			font-size: 150%;
 			vertical-align: bottom;
@@ -137,7 +139,7 @@ html,body {
 
 			color: #30261d;
 			color: #3d3935;
-			font-family: "Minion Web", "Georgia", serif;
+                        font-family: 'Merriweather', 'Minion Web', 'Georgia', serif;
 
 			width: 100%;
 			
@@ -145,6 +147,8 @@ html,body {
 		p {
 		/*	padding-left: 20px;
 		*/	padding-right: 20px;
+                        margin-block: 0.8em 1.2em;
+                        hyphens: auto;
 		}		
 		li { list-style-type: square; padding-bottom: 5px; }		
 		pre {
@@ -165,7 +169,7 @@ html,body {
 		#dict-def {
 			margin-top: 10px;
 			display: inline-block;
-			font-family: Georgia;
+                        font-family: 'Merriweather', Georgia, serif;
 		}
 		strong {
 		}
@@ -202,6 +206,7 @@ html,body {
 		
 		a:not(.label) {
 			color: #222;
+                        text-underline-offset: 0.15em;
 			text-decoration: none;
 			border-bottom: 1px solid #e8e8e8;
 			transition: border-bottom 0.2s;
@@ -356,7 +361,7 @@ ul.publications li {
 
     text-decoration: none;
     text-transform: uppercase;
-    font-family: "Minion Web", "Georgia", serif;
+    font-family: 'Merriweather', 'Minion Web', 'Georgia', serif;
     color: #fff;
 }
 .headerphoto > a {
@@ -371,7 +376,7 @@ ul.publications li {
     border-left: 1px solid #eee;
     text-transform: none;
 
-    font-family: Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
+    font-family: 'Inter', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
 
 }
 .outer {
@@ -456,3 +461,8 @@ ul.publications li {
 .post-desc {
   flex: 1 1 auto;
 }
+
+@media (min-width: 48rem) {
+  body { line-height: 1.45; }
+}
+

--- a/css/main.css
+++ b/css/main.css
@@ -3,11 +3,15 @@
 
 		}
                 body {
-                        font-family: 'Inter', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
+                        font-family: -apple-system, BlinkMacSystemFont,
+                                "Helvetica Neue", Helvetica,
+                                "Nimbus Sans", "Liberation Sans",
+                                Arial, sans-serif;
                         margin: 0 0 0 0;
                         padding: 0;
                         font-size: 18px;
                         line-height: 1.5;
+                        hyphens: auto;
 
                 }
 	
@@ -378,7 +382,10 @@ ul.publications li {
     border-left: 1px solid #eee;
     text-transform: none;
 
-    font-family: 'Inter', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont,
+        "Helvetica Neue", Helvetica,
+        "Nimbus Sans", "Liberation Sans",
+        Arial, sans-serif;
 
 }
 .outer {


### PR DESCRIPTION
## Summary
- extend Inter and Merriweather stacks with previous fonts as fallbacks
- increase default line-height for better readability

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_6873d30b03608326aff35a46b11ea86e