### PR TITLE
Add pre-commit linting for CSS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  precommit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+    - id: trailing-whitespace
+      files: ^css/.*\.css$
+      exclude: css/foundation\.min\.css
+    - id: end-of-file-fixer
+      files: ^css/.*\.css$
+      exclude: css/foundation\.min\.css
+- repo: https://github.com/pre-commit/mirrors-prettier
+  rev: v3.0.3
+  hooks:
+    - id: prettier
+      files: ^css/.*\.css$
+      exclude: css/foundation\.min\.css

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+css/foundation.min.css
+js/*.min.js
+js/foundation.js
+

--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ To preview the website locally, run the following command:
 ```bash
 bundle exec jekyll serve --host 0.0.0.0 --port 4000
 ```
+
+## Development
+
+Install [pre-commit](https://pre-commit.com/) to format CSS files automatically:
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/css/main.css
+++ b/css/main.css
@@ -1,428 +1,273 @@
-	html {
-			height: 100%;
+html {
+  height: 100%;
+}
+body {
+  margin: 0 0 0 0;
+  padding: 0;
+}
 
-		}
-		body {
-			
-			margin: 0 0 0 0;
-			padding: 0;
-			
-		}
-	
-html,body {
-    height:100%;
-		}
+html,
+body {
+  height: 100%;
+}
 
-		#layout{
-			position: relative;
-			height: 100%;
-		}
-		.sidebar {
-			display: block;
+#layout {
+  position: relative;
+  height: 100%;
+}
+.sidebar {
+  display: block;
 
-			background: #fff;
+  background: #fff;
 
-			text-align: right;
+  text-align: right;
 
-			min-height: 100%;
-			overflow: hidden;
+  min-height: 100%;
+  overflow: hidden;
 
-		    position: fixed;
-		    top: 0;
-		    bottom: 0;
-		    float: left;
-		}
-		.sidebar #prague {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  float: left;
+}
+.sidebar #prague {
+  margin-right: 1px;
+  padding-right: 0px;
+  margin-top: 0;
 
-			margin-right: 1px;
-			padding-right: 0px;
-			margin-top: 0;
+  width: 100%;
+  height: 100%;
 
-			width: 100%;
-			height: 100%;
+  display: inline-block;
+  background: transparent url(../images/prague3.jpg) center bottom no-repeat;
+  background-size: auto 100%;
 
-			display: inline-block;
-			background: transparent url(../images/prague3.jpg) center bottom no-repeat;
-			background-size: auto 100%;
+  text-decoration: none;
+  text-align: right;
 
-			text-decoration: none;
-			text-align: right;
+  padding: 0;
 
-			padding: 0;
+  margin-left: -4px;
+  border-right: 4px solid rgba(230, 230, 230, 0.6);
 
-			margin-left: -4px;
-			border-right: 4px solid rgba(230, 230, 230, 0.6);
+  float: left;
+}
 
-		    float: left;
-		}
+.sidebar #prague span {
+  display: none;
+  text-align: right;
 
-		.sidebar #prague span {
-			display: none;
-			text-align: right;
+  background: none;
+  width: auto;
+  height: 100%;
+  line-height: 100%;
 
-			background: none;
-			width: auto;
-			height: 100%;
-			line-height: 100%;
-			
-			color: #fff;
-			text-decoration: none;
+  color: #fff;
+  text-decoration: none;
 
-			text-transform: uppercase;
+  text-transform: uppercase;
 
-			padding: 14px;
-			font-family: "Minion Web", "Georgia", serif;
+  padding: 14px;
+  font-family: "Minion Web", "Georgia", serif;
 
-			font-size: 150%;
-			vertical-align: bottom;
-		}
-		.sidebar #prague:hover span {
-			display: block; 
-			vertical-align: bottom;
-			background: rgba(0, 0, 0, 0.2);
-		}
-		.sidebar #prague:hover {
-			border-right: 4px solid rgba(0, 0, 0, 0.4);
-		}
-		.sidebar, #spacer {
-			width: 30%;
-			min-width: 300px;
-			max-width: 480px;
-		}
-		#spacer {
-			display: inline-block;
-			height: 0;
-		}
+  font-size: 150%;
+  vertical-align: bottom;
+}
+.sidebar #prague:hover span {
+  display: block;
+  vertical-align: bottom;
+  background: rgba(0, 0, 0, 0.2);
+}
+.sidebar #prague:hover {
+  border-right: 4px solid rgba(0, 0, 0, 0.4);
+}
+.sidebar,
+#spacer {
+  width: 30%;
+  min-width: 300px;
+  max-width: 480px;
+}
+#spacer {
+  display: inline-block;
+  height: 0;
+}
 
-		.content {
-			display: inline-block;
-			max-width: 680px;
-			min-width: 60px;
-			margin-left: 25px;
-			margin-right: 20px;
-			padding-bottom: 40px;
-		}
+.content {
+  display: inline-block;
+  max-width: 680px;
+  min-width: 60px;
+  margin-left: 25px;
+  margin-right: 20px;
+  padding-bottom: 40px;
+}
 
-		
-		h1, h2 {
+h1,
+h2 {
+}
+h2 {
+  text-transform: uppercase;
+  margin: 2em 0 0 0;
+  color: #333;
+  font-size: 120%;
+  font-weight: normal;
+  border-bottom: 1px solid #ddd;
 
-		}
-		h2 {
-			text-transform: uppercase;
-			margin: 2em 0 0 0;
-			color: #333;
-			font-size: 120%;
-			font-weight: normal;
-			border-bottom: 1px solid #ddd;	
-			
-			line-height: 130%;
-			vertical-align: baseline;
-			
-			margin-bottom: 1em;
-		}
+  line-height: 130%;
+  vertical-align: baseline;
 
-			
-		.content ul {
-			padding-left: 20px;
-		}
+  margin-bottom: 1em;
+}
 
-		h1 {
-			clear: none;
-			display: inline-block;
-			
-			/*color: white;
-			
+.content ul {
+  padding-left: 20px;
+}
+
+h1 {
+  clear: none;
+  display: inline-block;
+
+  /*color: white;
+
 			text-shadow: 1px 1px 0px #000;*/
-			margin-top: 40px;
+  margin-top: 40px;
 
-			color: #30261d;
-			color: #3d3935;
-			font-family: "Minion Web", "Georgia", serif;
+  color: #30261d;
+  color: #3d3935;
+  font-family: "Minion Web", "Georgia", serif;
 
-			width: 100%;
-			
-		}
-		p {
-		/*	padding-left: 20px;
-		*/	padding-right: 20px;
-		}		
-		li { list-style-type: square; padding-bottom: 5px; }		
-		pre {
-			overflow-x: auto;
-		}
-		pre code {
-			display: inline-block;
-			padding: 0.4em;
-		}
-		h3 {
-			margin: 1.2em 0 0.4em 0;
-			color: #666;
-			font-size: 100%;
-			font-weight: bold;
-			/* text-transform: capitalize; */
-		}
-		
-		#dict-def {
-			margin-top: 10px;
-			display: inline-block;
-			font-family: Georgia;
-		}
-		strong {
-		}
-		cite {
-			font-size:8pt;
-			top: -4pt;
-			position: relative;
+  width: 100%;
+}
+p {
+  /*	padding-left: 20px;
+		*/
+  padding-right: 20px;
+}
+li {
+  list-style-type: square;
+  padding-bottom: 5px;
+}
+pre {
+  overflow-x: auto;
+}
+pre code {
+  display: inline-block;
+  padding: 0.4em;
+}
+h3 {
+  margin: 1.2em 0 0.4em 0;
+  color: #666;
+  font-size: 100%;
+  font-weight: bold;
+  /* text-transform: capitalize; */
+}
 
-			
-			vertical-align: top;
-			font-style: normal;
-			font-weight: bold;
-		}
-		cite a {
-			text-decoration: none;
-			color: #33251b;
-		}
-		.notes {
-			margin: 0;
-		}
-		.notes dt {
-			float: left;
-			color: #33251b;
-		}
-		.notes dt {
-			float: left;
-			color: #33251b;
-			margin: 0;
-			padding: 0;
-		}
-		.notes dd {
-			margin-left: 1.8em;
-		}
-		
-		a:not(.label) {
-			color: #222;
-			text-decoration: none;
-			border-bottom: 1px solid #e8e8e8;
-			transition: border-bottom 0.2s;
-		}
-		a:not(.label):hover, a:not(.label):focus {
-			border-bottom: 1px solid #222;
-			text-decoration: none;
-		}
+#dict-def {
+  margin-top: 10px;
+  display: inline-block;
+  font-family: Georgia;
+}
+strong {
+}
+cite {
+  font-size: 8pt;
+  top: -4pt;
+  position: relative;
 
-	#frontpage #instafeed {
-		line-height: 0px;
-	}
+  vertical-align: top;
+  font-style: normal;
+  font-weight: bold;
+}
+cite a {
+  text-decoration: none;
+  color: #33251b;
+}
+.notes {
+  margin: 0;
+}
+.notes dt {
+  float: left;
+  color: #33251b;
+}
+.notes dt {
+  float: left;
+  color: #33251b;
+  margin: 0;
+  padding: 0;
+}
+.notes dd {
+  margin-left: 1.8em;
+}
 
-		#frontpage #instafeed img {
-			display: block;
-			width: 75px;
-			height: 75px;
-		}
-		#frontpage #instafeed a {
-			display: inline-block;
-			border: 0px solid #999;
-			opacity:0.3;
-			margin: 0 4px 4px 0;
+a:not(.label) {
+  color: #222;
+  text-decoration: none;
+  border-bottom: 1px solid #e8e8e8;
+  transition: border-bottom 0.2s;
+}
+a:not(.label):hover,
+a:not(.label):focus {
+  border-bottom: 1px solid #222;
+  text-decoration: none;
+}
 
-		}
+#frontpage #instafeed {
+  line-height: 0px;
+}
 
-		#frontpage #instafeed a:hover {
-			opacity:1.0;
-		}
+#frontpage #instafeed img {
+  display: block;
+  width: 75px;
+  height: 75px;
+}
+#frontpage #instafeed a {
+  display: inline-block;
+  border: 0px solid #999;
+  opacity: 0.3;
+  margin: 0 4px 4px 0;
+}
 
-	    .content .inner {
-        padding: 0em 1em 0 1em;
-    }
+#frontpage #instafeed a:hover {
+  opacity: 1;
+}
 
-    @media (max-height: 700px) {
-		.sidebar #prague {
-	    	min-height: 500px;
-			max-height: 100%;
+.content .inner {
+  padding: 0em 1em 0 1em;
+}
 
-		}
+@media (max-height: 700px) {
+  .sidebar #prague {
+    min-height: 500px;
+    max-height: 100%;
+  }
+}
 
-	}
-
-	@media (max-width: 1000px) {
-		@media (max-height: 700px) {
-		.sidebar #prague {
-	    	min-height: 0;
-		}
-		}
-		.sidebar {
-			background: black;
-		}
-			.sidebar #prague {
-			    border: 0;
-		    	margin: 0;
-				margin-right: 1px;
-		    	padding: 0;
-
-		    	width: 100%;
-		    	
-				max-height: 100%;
-
-			}
-			.content {
-				max-width: 1000px;
-			}
-
-			#layout {
-				width: 100%;
-			}
-    .sidebar {
-    	height: 150px;
-    	min-height: 150px;
-    	max-width: 100%;
-        width: 100%;
-
-        position: relative;
-        padding: 0 0 0 0;
-        overflow: hidden;
-       	border: 0;
-    	background: black url(../images/prague3.jpg) bottom center no-repeat;
-    	background-size: 150% auto;
-
-    }
+@media (max-width: 1000px) {
+  @media (max-height: 700px) {
     .sidebar #prague {
-    	height: 150px;
-    	width: 100%;
-    	max-width: 100%;
-    	
-    	margin: 0;
-    	padding: 0;
-    	
-		background: none;
-
-    	border-bottom: 4px solid rgba(230, 230, 230, 0.6);
+      min-height: 0;
     }
+  }
+  .sidebar {
+    background: black;
+  }
+  .sidebar #prague {
+    border: 0;
+    margin: 0;
+    margin-right: 1px;
+    padding: 0;
 
-    .content {
-        width: inherit;
-    }
-
-    p {
-    	padding-right: 0;
-    }
-
-
-    .content, #layout {
-    	margin: 0;
-    	left: 0;
-    }
-
-    .sidebar img {
-        display: none;
-        visibility: hidden;
-        height: 0px;
-    }
-
-    .header {
-        text-align: center;
-        top: auto;
-        margin: 3em auto;
-        position: static;
-    }
-
-    #layout {
-        padding: 0;
-    }
-    h1 {
-        font-size: 2.25rem;
-    }
-}
-
-
-ul.publications li {
-	padding-bottom: 1em;
-}
-.pub_actions {
-	padding-top: 0.2em;
-}
-.reveal { outline: none; }
-
-
-
-.headerphoto {
-    background-color: white;
-    border-bottom: 1px solid #aaa;
-    padding: 0.5em 1em;
     width: 100%;
-    position: fixed;
-    top: 0;
-    bottom: auto;
 
-    text-decoration: none;
-    text-transform: uppercase;
-    font-family: "Minion Web", "Georgia", serif;
-    color: #fff;
-}
-.headerphoto > a {
-  border-bottom: none !important;
-}
-.headerphoto > a:hover, .headerphoto > a:focus {
-  border-bottom: none !important;
-}
-.photography {
-    margin-left: 1em;
-    padding-left: 1em;
-    border-left: 1px solid #eee;
-    text-transform: none;
-
-    font-family: Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
-
-}
-.outer {
-    background-color: #fff;
-    position: relative;
-    height: 150px;
-    border-bottom: 1px solid #eee;
-}
-.outer .headerphoto {
-    position: absolute;
-    bottom: 0;
-    z-index: 2;
-    top: auto;
-    background: rgba(230, 230, 230, 0.6);
-}
-.photos {
-    background-color: #fff;
-    margin-top: 5em;
-    margin-left: auto;
-    margin-right: auto;
-    text-align: center;
-}
-.photos h2 {
-	font-weight: bold;
-	border-bottom: none;
-	font-size: 170%;
-	color: #555;
-}
-
-.photo .image {
-    display: block;
+    max-height: 100%;
+  }
+  .content {
     max-width: 1000px;
-    margin-left: auto;
-    margin-right: auto;
-    border-bottom: 2px solid #ddd;
-}
-.photo {
-    margin-bottom: 4em;
-    margin-left: auto;
-    margin-right: auto;
-    text-align: right;
-}
+  }
 
-.caption {
-    padding: 0.3em 15px 0.3em 0;
-    text-align: right;
-    max-width: 1030px;
-    margin-left: auto;
-    margin-right: auto;
-}
-.outer .banner {
+  #layout {
+    width: 100%;
+  }
+  .sidebar {
     height: 150px;
     min-height: 150px;
     max-width: 100%;
@@ -433,8 +278,160 @@ ul.publications li {
     overflow: hidden;
     border: 0;
     background: black url(../images/prague3.jpg) bottom center no-repeat;
-    background-size: 100% auto;
+    background-size: 150% auto;
+  }
+  .sidebar #prague {
+    height: 150px;
+    width: 100%;
+    max-width: 100%;
 
+    margin: 0;
+    padding: 0;
+
+    background: none;
+
+    border-bottom: 4px solid rgba(230, 230, 230, 0.6);
+  }
+
+  .content {
+    width: inherit;
+  }
+
+  p {
+    padding-right: 0;
+  }
+
+  .content,
+  #layout {
+    margin: 0;
+    left: 0;
+  }
+
+  .sidebar img {
+    display: none;
+    visibility: hidden;
+    height: 0px;
+  }
+
+  .header {
+    text-align: center;
+    top: auto;
+    margin: 3em auto;
+    position: static;
+  }
+
+  #layout {
+    padding: 0;
+  }
+  h1 {
+    font-size: 2.25rem;
+  }
+}
+
+ul.publications li {
+  padding-bottom: 1em;
+}
+.pub_actions {
+  padding-top: 0.2em;
+}
+.reveal {
+  outline: none;
+}
+
+.headerphoto {
+  background-color: white;
+  border-bottom: 1px solid #aaa;
+  padding: 0.5em 1em;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  bottom: auto;
+
+  text-decoration: none;
+  text-transform: uppercase;
+  font-family: "Minion Web", "Georgia", serif;
+  color: #fff;
+}
+.headerphoto > a {
+  border-bottom: none !important;
+}
+.headerphoto > a:hover,
+.headerphoto > a:focus {
+  border-bottom: none !important;
+}
+.photography {
+  margin-left: 1em;
+  padding-left: 1em;
+  border-left: 1px solid #eee;
+  text-transform: none;
+
+  font-family:
+    Helvetica Neue,
+    Helvetica,
+    Roboto,
+    Arial,
+    sans-serif;
+}
+.outer {
+  background-color: #fff;
+  position: relative;
+  height: 150px;
+  border-bottom: 1px solid #eee;
+}
+.outer .headerphoto {
+  position: absolute;
+  bottom: 0;
+  z-index: 2;
+  top: auto;
+  background: rgba(230, 230, 230, 0.6);
+}
+.photos {
+  background-color: #fff;
+  margin-top: 5em;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+.photos h2 {
+  font-weight: bold;
+  border-bottom: none;
+  font-size: 170%;
+  color: #555;
+}
+
+.photo .image {
+  display: block;
+  max-width: 1000px;
+  margin-left: auto;
+  margin-right: auto;
+  border-bottom: 2px solid #ddd;
+}
+.photo {
+  margin-bottom: 4em;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: right;
+}
+
+.caption {
+  padding: 0.3em 15px 0.3em 0;
+  text-align: right;
+  max-width: 1030px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.outer .banner {
+  height: 150px;
+  min-height: 150px;
+  max-width: 100%;
+  width: 100%;
+
+  position: relative;
+  padding: 0 0 0 0;
+  overflow: hidden;
+  border: 0;
+  background: black url(../images/prague3.jpg) bottom center no-repeat;
+  background-size: 100% auto;
 }
 
 .posts li {


### PR DESCRIPTION
## Summary
- add Prettier-based pre-commit hooks for CSS
- add a GitHub action to run pre-commit
- document pre-commit usage in README
- format `css/main.css`

## Testing
- `pre-commit run --all-files`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687428ca90848326937a51427519d319