### PR TITLE
Restore Instagram feed preview on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,6 +3,8 @@ layout: default
 title: Joachim Daiber
 ---
 
+<div id="frontpage">
+
 ## About me
 
 I am an applied scientist focused on machine learning and practical engineering. I was a co-founder and CTO of Objective, Inc. ([TechCrunch](https://techcrunch.com/2023/10/18/objective-emerges-from-stealth-to-deliver-multimodal-search-to-developers-as-an-api-platform/)), which was acquired by Upwork in November 2024.
@@ -51,3 +53,23 @@ in applications and evaluation of large language and vision models, machine tran
 {% endif %}
 
 {% endfor %}
+
+<div id="instafeed"></div>
+<script src="{{ '/js/instafeed.js' | relative_url }}"></script>
+
+{% raw %}
+<script type="text/javascript">
+    var feed = new Instafeed({
+                get: 'user',
+                userId: 601088313,
+        accessToken: '601088313.1677ed0.df46ed351a5f44bab606823c253be9ff',
+                links: true,
+                limit: '6',
+        resolution: 'thumbnail',
+        template: '<a href="{{link}}"><img src="{{image}}" /></a>'
+    });
+    feed.run();
+</script>
+{% endraw %}
+
+</div>


### PR DESCRIPTION
## Summary
- Reintroduce Instagram photo feed on homepage using existing Instafeed.js configuration
- Wrap home page content in `#frontpage` to enable CSS styling

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68912d3981dc832691a4790ccf470691